### PR TITLE
added test to see if users are defined

### DIFF
--- a/index.php
+++ b/index.php
@@ -110,6 +110,14 @@ if (is_file('config/users.php') && is_readable('config/users.php')) {
     error_log('The file config/users.php does not exist, proceeding without user authentication.');
 }
 
+if (isset($users) && $users !== '') {
+    $user_authentication = true;
+} else {    
+    $user_authentication = false;
+    error_log('The file config/users.php does not define any users, proceeding without user authentication.');    
+}
+
+
 /**
  * if needed, we request the user to login
  */


### PR DESCRIPTION
I added this test to index.php to cope with condition when config/users.php exists but where $users in config/users.php is not defined.

It bypasses auth to match the text in config/users.php that says thats what is supposed to happen.

This is designed to solve the issue i raised in https://github.com/Art-of-WiFi/UniFi-API-browser/issues/84.

I am not a coder, this is my first ever real code PR so please go gentle on me if my code is crap.

This can be easily tested by pulling scyto/unifibrowser:noauth - and adding a new variable when running the container called NOAPIBROWSERAUTH   - setting to 1 bypasses auth and setting it to 0 keeps auth. 